### PR TITLE
Changed dump method to public String so that the tool can be used to get...

### DIFF
--- a/morfologik-tools/src/main/java/morfologik/tools/FSADumpTool.java
+++ b/morfologik-tools/src/main/java/morfologik/tools/FSADumpTool.java
@@ -78,8 +78,11 @@ public final class FSADumpTool extends Tool {
 	/**
 	 * Dumps the content of a dictionary to a file.
 	 */
-	private void dump(File dictionaryFile)
+	public String dump(File dictionaryFile)
 	        throws UnsupportedEncodingException, IOException {
+		
+		String dictAsString = "";
+		
 		final long start = System.currentTimeMillis();
 
 		final Dictionary dictionary;
@@ -184,8 +187,9 @@ public final class FSADumpTool extends Tool {
 					t = "";
 				builder.append(t);
 				builder.append('\n');
-
-				osw.write(builder.toString());
+				
+				dictAsString = builder.toString();
+				osw.write(dictAsString);
 				sequences++;
 			}
 			osw.flush();
@@ -216,6 +220,7 @@ public final class FSADumpTool extends Tool {
 		                (int) (sequences / (millis / 1000.0))));
 
 		os.flush();
+		return dictAsString;
 	}
 
 	/**


### PR DESCRIPTION
... the decoded dictionary as a String variable.  This is useful for manipulating the dictionary from a java app.