### PR TITLE
Add DependencyConvergence checks to parent pom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ target/
 *.iml
 .idea/compiler.xml
 .idea/encodings.xml
+.idea/findbugs-idea.xml
 .idea/copyright/profiles_settings.xml
 .idea/libraries/Maven__com_carrotsearch_hppc_0_5_3.xml
 .idea/libraries/Maven__com_carrotsearch_junit_benchmarks_0_7_2.xml

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,27 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${version.maven-enforcer-plugin}</version>
+        <configuration>
+          <rules>
+            <DependencyConvergence/>
+          </rules>
+        </configuration>
+        <executions>
+          <execution>
+            <id>enforce-dependency-convergence</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 
   <profiles>
@@ -336,6 +357,12 @@
           <artifactId>randomizedtesting-runner</artifactId>
           <version>${version.randomizedtesting}</version>
           <scope>test</scope>
+          <exclusions>
+            <exclusion><!-- prevents maven-enforcer DependencyConvergence error - bring in our own version below -->
+              <groupId>junit</groupId>
+              <artifactId>junit</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This fixes a dependency convergence issue introduced via https://github.com/morfologik/morfologik-stemming/commit/3ada8d8b47ca8495de3415d5e76dbf99fa971760. 

Any projects that currently depend on morfologik 2.1.0 and have [maven-enforcer dependency convergence](https://maven.apache.org/enforcer/enforcer-rules/dependencyConvergence.html) enabled need to add a `morfologik-stemming` entry in dependencyManagement to deal with the conflict.

I came across this when upgrading my languagetool dependency from 3.1 to 3.3 - see https://github.com/languagetool-org/languagetool/pull/342#issuecomment-205774094 for additional context.

I added a dependency convergence check to the morfologik parent so that I could test this change by running `mvn validate`. I'm happy to remove that, or move it, if you don't want to enforce dependency convergence.