### PR TITLE
Case-changed words are always good suggestions.

### DIFF
--- a/morfologik-speller/src/main/java/morfologik/speller/Speller.java
+++ b/morfologik-speller/src/main/java/morfologik/speller/Speller.java
@@ -364,7 +364,7 @@ public class Speller {
     candidates.clear();
     if (word.length() > 0 && word.length() < MAX_WORD_LENGTH && !isInDictionary(word)) {
       List<String> wordsToCheck = new ArrayList<String>();
-      if (replacementsTheRest != null) {  
+      if (replacementsTheRest != null && word.length() > 1) {
         for (final String wordChecked : getAllReplacements(word, 0, 0)) {
           boolean found = false;
           if (isInDictionary(wordChecked)) {

--- a/morfologik-speller/src/main/java/morfologik/speller/Speller.java
+++ b/morfologik-speller/src/main/java/morfologik/speller/Speller.java
@@ -364,7 +364,7 @@ public class Speller {
     candidates.clear();
     if (word.length() > 0 && word.length() < MAX_WORD_LENGTH && !isInDictionary(word)) {
       List<String> wordsToCheck = new ArrayList<String>();
-      if (replacementsTheRest != null && word.length() > MIN_WORD_LENGTH) {
+      if (replacementsTheRest != null) {  
         for (final String wordChecked : getAllReplacements(word, 0, 0)) {
           boolean found = false;
           if (isInDictionary(wordChecked)) {

--- a/morfologik-speller/src/main/java/morfologik/speller/Speller.java
+++ b/morfologik-speller/src/main/java/morfologik/speller/Speller.java
@@ -370,7 +370,7 @@ public class Speller {
           if (isInDictionary(wordChecked)) {
             candidates.add(new CandidateData(wordChecked, 0));
             found = true;
-          } else if (dictionaryMetadata.isConvertingCase()) {
+          } else {
             String lowerWord = wordChecked.toLowerCase(dictionaryMetadata.getLocale());
             String upperWord = wordChecked.toUpperCase(dictionaryMetadata.getLocale());
             if (isInDictionary(lowerWord)) {


### PR DESCRIPTION
Use case-changed words as suggestions even in languages that are "case-sensitive" like German. The suggested word is always the correct word form in the dictionary. 