### PR TITLE
micro performance optimization

### DIFF
--- a/morfologik-speller/src/main/java/morfologik/speller/Speller.java
+++ b/morfologik-speller/src/main/java/morfologik/speller/Speller.java
@@ -579,9 +579,11 @@ public class Speller {
     if (x == y) {
       return true;
     }
-    if (dictionaryMetadata.getEquivalentChars() != null && dictionaryMetadata.getEquivalentChars().containsKey(x)
-        && dictionaryMetadata.getEquivalentChars().get(x).contains(y)) {
-      return true;
+    if (dictionaryMetadata.getEquivalentChars() != null) {
+      List<Character> chars = dictionaryMetadata.getEquivalentChars().get(x);
+      if (chars != null && chars.contains(y)) {
+        return true;
+      }
     }
     if (dictionaryMetadata.isIgnoringDiacritics()) {
       String xn = Normalizer.normalize(Character.toString(x), Form.NFD);


### PR DESCRIPTION
`areEqual()` runs `containsKey()` and then `get()`, I think it's faster by running `get()` directly? I found that `areEqual` takes 7% of all the CPU usage on languagetool.org, so any optimization there is welcome.