### PR TITLE
fix replaceRunOnWords() not working for words that are uppercase at sentence start

### DIFF
--- a/morfologik-speller/src/main/java/morfologik/speller/Speller.java
+++ b/morfologik-speller/src/main/java/morfologik/speller/Speller.java
@@ -340,6 +340,17 @@ public class Speller {
             candidates.add(DictionaryLookup.applyReplacements(firstCh + " " + wordToCheck.subSequence(i, wordToCheck.length()),
                 dictionaryMetadata.getOutputConversionPairs()).toString());
           }
+        } else if (Character.isUpperCase(firstCh.charAt(0))) {
+          // a word that's uppercase just because used at sentence start
+          final String firstChLc = wordToCheck.subSequence(0, i).toString().toLowerCase(dictionaryMetadata.getLocale());
+          if (isInDictionary(firstChLc) && isInDictionary(wordToCheck.subSequence(i, wordToCheck.length()))) {
+            if (dictionaryMetadata.getOutputConversionPairs().isEmpty()) {
+              candidates.add(firstCh + " " + wordToCheck.subSequence(i, wordToCheck.length()));
+            } else {
+              candidates.add(DictionaryLookup.applyReplacements(firstCh + " " + wordToCheck.subSequence(i, wordToCheck.length()),
+                  dictionaryMetadata.getOutputConversionPairs()).toString());
+            }
+          }
         }
       }
     }

--- a/morfologik-speller/src/test/java/morfologik/speller/SpellerTest.java
+++ b/morfologik-speller/src/test/java/morfologik/speller/SpellerTest.java
@@ -39,6 +39,7 @@ public class SpellerTest {
     final Speller spell = new Speller(dictionary);
     Assertions.assertThat(spell.replaceRunOnWords("abaka")).isEmpty();
     Assertions.assertThat(spell.replaceRunOnWords("abakaabace")).contains("abaka abace");
+    Assertions.assertThat(spell.replaceRunOnWords("Abakaabace")).contains("Abaka abace");
 
     // Test on an morphological dictionary - should work as well
     final URL url1 = getClass().getResource("test-infix.dict");


### PR DESCRIPTION
`Speller.replaceRunOnWords()` doesn't seem to work for words like `Everytime`, i.e. it doesn't suggest `Every time`, whereas `everytime` correctly suggests `every time`. This tries to fix that.